### PR TITLE
ci: Fixup release workflow syntax issues

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
-    branches: main
-    
+
 jobs:
   release:
     name: Perform release
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
# Summary

Closes #33 by fixing some syntax issues in the release workflow.

# Changes
- Removes unsupported `branches` arg from `workflow_dispatch` trigger definition.
- Adds an `runs-on` argument to release job.
