### PR TITLE
chore: Move CLI entrypoint to __main__.py

### DIFF
--- a/plugboard/__main__.py
+++ b/plugboard/__main__.py
@@ -1,0 +1,7 @@
+"""Provides CLI entrypoint."""
+
+from plugboard.cli import app
+
+
+if __name__ == "__main__":
+    app()

--- a/plugboard/cli/__init__.py
+++ b/plugboard/cli/__init__.py
@@ -13,6 +13,3 @@ app = typer.Typer(
     pretty_exceptions_show_locals=False,
 )
 app.add_typer(process_app, name="process")
-
-if __name__ == "__main__":
-    app()


### PR DESCRIPTION
# Summary
Closes #37 by moving CLI entrypoint.

# Changes
* Now uses canonical `__main__.py` as entrypoint for CLI. 