### PR TITLE
ci: Separate PR workflows

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,22 +7,10 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
       - reopened
 
 jobs:
-  pr-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check PR title
-        uses: amannn/action-semantic-pull-request@v5
-        if: github.event_name == 'pull_request_target'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          wip: true
-
   lint-test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,20 @@
+name: Lint and test
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  pr-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true


### PR DESCRIPTION
# Summary
Resolves #78. 

# Changes
* PR title check now in separate workflow, and should work against PRs created from forks.
* Triggers on existing lint/test workflow updated.