### PR TITLE
ci: Add codecov action and status badge

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -52,10 +52,14 @@ jobs:
         if: always()
 
       - name: Tests
-        run: uv run pytest --cov=plugboard --cov-report json .
+        run: uv run pytest --cov=plugboard --cov-report=xml .
         if: always()
 
-      # TODO: Reinstate coverage badge creation
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: plugboard-dev/plugboard
 
       - name: Notebook output cleared
         run: find . -name '*.ipynb' -not -path "./.venv/*" -exec uv run nbstripout --verify {} +

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 </div>
 
 <div align="center" class="badge-section">
+  <br>
   <a href="https://pypi.org/project/plugboard/", alt="PyPI version">
     <img alt="PyPI" src="https://img.shields.io/pypi/v/plugboard?labelColor=075D7A&color=CC9C4A"></a>
   <a href="https://www.python.org/", alt="Python versions">

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@
 <hr>
 
 <div align="center" class="badge-section">
-
-![Version](https://img.shields.io/pypi/v/plugboard?labelColor=075D7A&color=CC9C4A)
-![Python](https://img.shields.io/pypi/pyversions/plugboard?labelColor=075D7A&color=CC9C4A)
-
-![Lint and test](https://github.com/plugboard-dev/plugboard/actions/workflows/lint-test.yaml/badge.svg)
-![Documentation](https://github.com/plugboard-dev/plugboard/actions/workflows/docs.yaml/badge.svg)
-[![Typing](https://img.shields.io/pypi/types/plugboard)](https://github.com/plugboard-dev/plugboard?labelColor=075D7A&color=CC9C4A)
-![License](https://img.shields.io/github/license/plugboard-dev/plugboard?labelColor=075D7A&color=CC9C4A)
-
+  <a href="https://pypi.org/project/plugboard/", alt="PyPI version">
+    <img alt="PyPI" src="https://img.shields.io/pypi/v/plugboard?labelColor=075D7A&color=CC9C4A"></a>
+  <a href="https://www.python.org/", alt="Python versions">
+    <img alt="Python" src="https://img.shields.io/pypi/pyversions/plugboard?labelColor=075D7A&color=CC9C4A"></a>
+  <a href="https://github.com/plugboard-dev/plugboard?tab=Apache-2.0-1-ov-file#readme", alt="License">
+    <img alt="License" src="https://img.shields.io/github/license/plugboard-dev/plugboard?labelColor=075D7A&color=CC9C4A"></a>
+  <br>
+  <a href="https://github.com/plugboard-dev/plugboard/actions/workflows/lint-test.yaml", alt="Lint and test">
+    <img alt="Lint and Test" src="https://github.com/plugboard-dev/plugboard/actions/workflows/lint-test.yaml/badge.svg"></a>
+  <a href="https://github.com/plugboard-dev/plugboard/actions/workflows/docs.yaml", alt="Documentation">
+    <img alt="Docs" src="https://github.com/plugboard-dev/plugboard/actions/workflows/docs.yaml/badge.svg"></a>
+  <a href="https://codecov.io/gh/plugboard-dev/plugboard" >
+    <img src="https://codecov.io/gh/plugboard-dev/plugboard/graph/badge.svg?token=4LU4K6TOLQ"/></a>
 </div>
 
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   </picture>
 </div>
 
-<hr>
-
 <div align="center" class="badge-section">
   <a href="https://pypi.org/project/plugboard/", alt="PyPI version">
     <img alt="PyPI" src="https://img.shields.io/pypi/v/plugboard?labelColor=075D7A&color=CC9C4A"></a>
@@ -24,6 +22,7 @@
     <img src="https://codecov.io/gh/plugboard-dev/plugboard/graph/badge.svg?token=4LU4K6TOLQ"/></a>
 </div>
 
+<hr>
 
 Plugboard is an **event-driven modelling and orchestration framework** in Python for simulating and driving complex processes with many interconnected stateful components.
 


### PR DESCRIPTION
# Summary
Adds [codecov](https://app.codecov.io/analytics/gh/plugboard-dev) integration and status badge.

# Changes
* Adds codecov integration to handle pytest coverage reports.
* Update badges to include codecov.
* Minor formatting adjustments to README.