### PR TITLE
ci: Fix docs and PyPI pipelines

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,8 @@ jobs:
       - name: checkout current branch
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          # Required: https://github.com/actions/checkout/issues/1471
+          fetch-depth: 0
 
       - name: Install python
         uses: actions/setup-python@v5

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          # Required: https://github.com/actions/checkout/issues/1471
+          fetch-depth: 0
 
       - name: Install python
         uses: actions/setup-python@v5


### PR DESCRIPTION
# Summary
Updates documentation and PyPI pipelines to trigger on [workflow_run](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) instead of tag. This is because GitHub [does not allow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow) one workflow to trigger another.

# Changes
* Updated pipelines to use workflow_run.