### PR TITLE
[WIP] fix: ZMQ Connector

### DIFF
--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -47,12 +47,12 @@ class ZMQProxy(multiprocessing.Process):
 
     def __init__(self, zmq_address: str = ZMQ_ADDR, maxsize: int = 2000) -> None:
         super().__init__()
-        self._zmq_address = zmq_address
-        self._zmq_proxy_lock = asyncio.Lock()
-        self._maxsize = maxsize
+        self._zmq_address: str = zmq_address
+        self._zmq_proxy_lock: asyncio.Lock = asyncio.Lock()
+        self._maxsize: int = maxsize
         self._pull_socket = create_socket(zmq.PULL, [(zmq.RCVHWM, 1)])
-        self._pull_socket_port = self._pull_socket.bind_to_random_port("tcp://*")
-        self._pull_socket_addr = f"{self._zmq_address}:{self._pull_socket_port}"
+        self._pull_socket_port: int = self._pull_socket.bind_to_random_port("tcp://*")
+        self._pull_socket_address: str = f"{self._zmq_address}:{self._pull_socket_port}"
         self._xsub_port: _t.Optional[int] = None
         self._xpub_port: _t.Optional[int] = None
         self._proxy_started: bool = False
@@ -74,7 +74,7 @@ class ZMQProxy(multiprocessing.Process):
                 return
             self._zmq_address = zmq_address
             self._maxsize = maxsize
-            self._pull_socket_addr = f"{self._zmq_address}:{self._pull_socket_port}"
+            self._pull_socket_address = f"{self._zmq_address}:{self._pull_socket_port}"
             self.start()
             self._proxy_started = True
 
@@ -117,7 +117,7 @@ class ZMQProxy(multiprocessing.Process):
         xpub_port = self._xpub_socket.bind_to_random_port("tcp://*")
 
         self._push_socket = create_socket(zmq.PUSH, [(zmq.RCVHWM, 1)], ctx=ctx)
-        self._push_socket.connect(self._pull_socket_addr)
+        self._push_socket.connect(self._pull_socket_address)
 
         return xsub_port, xpub_port
 

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -73,14 +73,6 @@ class ZMQProxy(multiprocessing.Process):
                 self._xsub_port, self._xpub_port = map(int, ports_msg)
             return self._xsub_port, self._xpub_port
 
-    @staticmethod
-    def _create_socket(socket_type: int, socket_opts: zmq_sockopts_t) -> zmq.Socket:
-        ctx = zmq.Context.instance()
-        socket = ctx.socket(socket_type)
-        for opt, value in socket_opts:
-            socket.setsockopt(opt, value)
-        return socket
-
     def run(self) -> None:
         """Multiprocessing entrypoint to run ZMQ proxy."""
         xsub_port, xpub_port = self._create_sockets()
@@ -103,6 +95,14 @@ class ZMQProxy(multiprocessing.Process):
         self._push_socket.connect(self._pull_socket_addr)
 
         return xsub_port, xpub_port
+
+    @staticmethod
+    def _create_socket(socket_type: int, socket_opts: zmq_sockopts_t) -> zmq.Socket:
+        ctx = zmq.Context.instance()
+        socket = ctx.socket(socket_type)
+        for opt, value in socket_opts:
+            socket.setsockopt(opt, value)
+        return socket
 
     def _close(self) -> None:
         self._xsub_socket.close(linger=0)

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -22,7 +22,16 @@ def create_socket(
     socket_opts: zmq_sockopts_t,
     ctx: _t.Optional[zmq.Context | zmq.asyncio.Context] = None,
 ) -> zmq.asyncio.Socket:
-    """Creates a ZeroMQ socket with the given type and options."""
+    """Creates a ZeroMQ socket with the given type and options.
+
+    Args:
+        socket_type: The type of socket to create.
+        socket_opts: The options to set on the socket.
+        ctx: The ZMQ context to use. Uses an async context by default.
+
+    Returns:
+        The created ZMQ socket.
+    """
     _ctx = ctx or zmq.asyncio.Context.instance()
     socket = _ctx.socket(socket_type)
     for opt, value in socket_opts:

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -224,7 +224,7 @@ class ZMQProxy(multiprocessing.Process):
         """Polls push sockets for messages and sends them to the proxy."""
         while True:
             # Set a timeout of 1 second to allow for new push sockets to be added
-            events = dict(await self._push_poller.poll(timeout=10000))
+            events = dict(await self._push_poller.poll(timeout=1000))
             async with asyncio.TaskGroup() as tg:
                 for socket in events:
                     tg.create_task(self._handle_push_socket(socket))

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -200,7 +200,8 @@ class ZMQProxy(multiprocessing.Process):
     async def _poll_push_sockets(self) -> None:
         """Polls push sockets for messages and sends them to the proxy."""
         while True:
-            events = dict(await self._push_poller.poll())
+            # Set a timeout of 1 second to allow for new push sockets to be added
+            events = dict(await self._push_poller.poll(timeout=1000))
             async with asyncio.TaskGroup() as tg:
                 for socket in events:
                     tg.create_task(self._handle_push_socket(socket))

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -50,29 +50,32 @@ class ZMQProxy(multiprocessing.Process):
         self._zmq_address: str = zmq_address
         self._zmq_proxy_lock: asyncio.Lock = asyncio.Lock()
         self._maxsize: int = maxsize
+
+        # Socket for receiving xsub and xpub ports from the subprocess
         self._pull_socket = create_socket(zmq.PULL, [(zmq.RCVHWM, 1)])
         self._pull_socket_port: int = self._pull_socket.bind_to_random_port("tcp://*")
         self._pull_socket_address: str = f"{self._zmq_address}:{self._pull_socket_port}"
-        self._xsub_port: _t.Optional[int] = None
-        self._xpub_port: _t.Optional[int] = None
-        self._proxy_started: bool = False
-        self._push_poller: zmq.asyncio.Poller = zmq.asyncio.Poller()
-        self._push_sockets: dict[str, zmq.asyncio.Socket] = {}
 
         # Socket for requesting push socket creation in the subprocess
         self._socket_req_socket = create_socket(zmq.REQ, [(zmq.RCVHWM, 1)])
-        self._socket_req_port: int = 0  # Will be set when the proxy subprocess starts
+        self._socket_req_port: int = self._socket_req_socket.bind_to_random_port("tcp://*")
+        self._socket_req_address: str = f"{self._zmq_address}:{self._socket_req_port}"
+
+        self._xsub_port: _t.Optional[int] = None
+        self._xpub_port: _t.Optional[int] = None
+
+        self._proxy_started: bool = False
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
-        keys_to_delete = (
+        rm_keys = (
             "_pull_socket",
             "_zmq_proxy_lock",
             "_push_poller",
             "_push_sockets",
             "_socket_req_socket",
         )
-        for key in keys_to_delete:
+        for key in rm_keys:
             if key in state:
                 del state[key]
         return state
@@ -89,6 +92,8 @@ class ZMQProxy(multiprocessing.Process):
             self._pull_socket_address = f"{self._zmq_address}:{self._pull_socket_port}"
             self.start()
             self._proxy_started = True
+            # Small delay to allow the proxy to start and connect to the sockets
+            await asyncio.sleep(0.1)
 
     async def get_proxy_ports(self) -> tuple[int, int]:
         """Returns tuple of form (xsub port, xpub port) for the ZMQ proxy."""
@@ -97,28 +102,15 @@ class ZMQProxy(multiprocessing.Process):
         async with self._zmq_proxy_lock:
             if self._xsub_port is None or self._xpub_port is None:
                 ports_msg = await self._pull_socket.recv_multipart()
-                # The first two values are xsub_port and xpub_port
-                self._xsub_port, self._xpub_port = map(int, ports_msg[:2])
-                # If there's a third value, it's the socket_req_port
-                if len(ports_msg) > 2:
-                    self._socket_req_port = int(ports_msg[2])
-                    self._socket_req_socket.connect(f"{self._zmq_address}:{self._socket_req_port}")
+                self._xsub_port, self._xpub_port = map(int, ports_msg)
             return self._xsub_port, self._xpub_port
 
     async def add_push_socket(self, topic: str, maxsize: int = 2000) -> str:
         """Adds a push socket for the given pubsub topic and returns the address."""
         if not self._proxy_started or self._xpub_port is None:
             raise RuntimeError("ZMQ proxy xpub port is not set.")
-        if self._socket_req_port == 0:
-            raise RuntimeError("Socket request port is not set.")
 
-        # Send request to create a push socket in the subprocess
-        request = {"action": "create_push_socket", "topic": topic, "maxsize": maxsize}
-
-        # Send the request to the subprocess
-        await self._socket_req_socket.send_json(request)
-
-        # Receive the response with the push socket address
+        await self._socket_req_socket.send_json({"topic": topic, "maxsize": maxsize})
         response = await self._socket_req_socket.recv_json()
 
         if "error" in response:
@@ -135,34 +127,57 @@ class ZMQProxy(multiprocessing.Process):
 
     async def _run(self) -> None:
         """Async multiprocessing entrypoint to run ZMQ proxy."""
+        self._push_poller: zmq.asyncio.Poller = zmq.asyncio.Poller()
+        self._push_sockets: dict[str, zmq.asyncio.Socket] = {}
+
         async with asyncio.TaskGroup() as tg:
             tg.create_task(asyncio.to_thread(self._run_pubsub_proxy))
-            tg.create_task(self._handle_socket_requests())
+            tg.create_task(self._handle_create_push_socket_requests())
             tg.create_task(self._poll_push_sockets())
 
-    async def _handle_socket_requests(self) -> None:
+    def _run_pubsub_proxy(self) -> None:
+        """Runs the ZMQ proxy for pubsub connections."""
+        xsub_port, xpub_port = self._create_pubsub_sockets()
+        ports_msg = [
+            str(xsub_port).encode(),
+            str(xpub_port).encode(),
+        ]
+        self._push_socket.send_multipart(ports_msg)
+        zmq.proxy(self._xsub_socket, self._xpub_socket)
+
+    def _create_pubsub_sockets(self) -> _t.Tuple[int, int]:
+        """Creates XSUB, XPUB and PUSH sockets for proxy.
+
+        Returns:
+            Tuple of (xsub_port, xpub_port)
+        """
+        ctx = zmq.Context.instance()
+        self._xsub_socket = create_socket(zmq.XSUB, [(zmq.RCVHWM, self._maxsize)], ctx=ctx)
+        xsub_port = self._xsub_socket.bind_to_random_port("tcp://*")
+
+        self._xpub_socket = create_socket(zmq.XPUB, [(zmq.SNDHWM, self._maxsize)], ctx=ctx)
+        xpub_port = self._xpub_socket.bind_to_random_port("tcp://*")
+
+        self._push_socket = create_socket(zmq.PUSH, [(zmq.RCVHWM, 1)], ctx=ctx)
+        self._push_socket.connect(self._pull_socket_address)
+
+        return xsub_port, xpub_port
+
+    async def _handle_create_push_socket_requests(self) -> None:
         """Handles requests to create sockets in the subprocess."""
         # Create a socket to receive socket creation requests
-        ctx = zmq.Context.instance()
-        self._socket_rep_socket = create_socket(zmq.REP, [], ctx=ctx)
-        # This port is passed to the main process via _create_sockets()
-        self._socket_rep_socket.bind_to_random_port("tcp://*")
+        self._socket_rep_socket = create_socket(zmq.REP, [])
+        self._socket_rep_socket.connect(self._socket_req_address)
 
-        try:
-            while True:
-                request = await self._socket_rep_socket.recv_json()
-                if request["action"] == "create_push_socket":
-                    try:
-                        push_address = await self._create_push_socket_in_subprocess(
-                            request["topic"], request["maxsize"]
-                        )
-                        await self._socket_rep_socket.send_json({"push_address": push_address})
-                    except Exception as e:
-                        await self._socket_rep_socket.send_json({"error": str(e)})
-        finally:
-            self._socket_rep_socket.close(linger=0)
+        while True:
+            request = await self._socket_rep_socket.recv_json()
+            try:
+                push_address = await self._create_push_socket(request["topic"], request["maxsize"])
+                await self._socket_rep_socket.send_json({"push_address": push_address})
+            except Exception as e:
+                await self._socket_rep_socket.send_json({"error": str(e)})
 
-    async def _create_push_socket_in_subprocess(self, topic: str, maxsize: int) -> str:
+    async def _create_push_socket(self, topic: str, maxsize: int) -> str:
         """Creates a push socket in the subprocess and returns its address."""
         # Create the SUB socket to receive messages from the XPUB socket
         sub_socket = create_socket(
@@ -193,41 +208,8 @@ class ZMQProxy(multiprocessing.Process):
         push_socket = self._push_sockets[topic]
         await push_socket.send_multipart(msg)
 
-    def _run_pubsub_proxy(self) -> None:
-        """Runs the ZMQ proxy for pubsub connections."""
-        xsub_port, xpub_port, socket_req_port = self._create_sockets()
-        ports_msg = [
-            str(xsub_port).encode(),
-            str(xpub_port).encode(),
-            str(socket_req_port).encode(),
-        ]
-        self._push_socket.send_multipart(ports_msg)
-        zmq.proxy(self._xsub_socket, self._xpub_socket)
-
-    def _create_sockets(self) -> _t.Tuple[int, int, int]:
-        """Creates XSUB, XPUB, REP and PUSH sockets for proxy.
-
-        Returns:
-            Tuple of (xsub_port, xpub_port, socket_req_port)
-        """
-        ctx = zmq.Context.instance()
-        self._xsub_socket = create_socket(zmq.XSUB, [(zmq.RCVHWM, self._maxsize)], ctx=ctx)
-        xsub_port = self._xsub_socket.bind_to_random_port("tcp://*")
-
-        self._xpub_socket = create_socket(zmq.XPUB, [(zmq.SNDHWM, self._maxsize)], ctx=ctx)
-        xpub_port = self._xpub_socket.bind_to_random_port("tcp://*")
-
-        self._socket_rep_socket = create_socket(zmq.REP, [], ctx=ctx)
-        socket_req_port = self._socket_rep_socket.bind_to_random_port("tcp://*")
-
-        self._push_socket = create_socket(zmq.PUSH, [(zmq.RCVHWM, 1)], ctx=ctx)
-        self._push_socket.connect(self._pull_socket_address)
-
-        return xsub_port, xpub_port, socket_req_port
-
     def _close(self) -> None:
         self._xsub_socket.close(linger=0)
         self._xpub_socket.close(linger=0)
         self._push_socket.close(linger=0)
-        if hasattr(self, "_socket_rep_socket"):
-            self._socket_rep_socket.close(linger=0)
+        self._socket_rep_socket.close(linger=0)

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -195,6 +195,9 @@ class ZMQProxy(multiprocessing.Process):
 
         while True:
             request = self._socket_rep_socket.recv_json()
+            if not (isinstance(request, dict) and "topic" in request and "maxsize" in request):
+                self._socket_rep_socket.send_json({"error": "Invalid request format."})
+                continue
             try:
                 push_address = self._create_push_socket(request["topic"], request["maxsize"])
                 self._socket_rep_socket.send_json({"push_address": push_address})

--- a/plugboard/_zmq/zmq_proxy.py
+++ b/plugboard/_zmq/zmq_proxy.py
@@ -67,6 +67,8 @@ class ZMQProxy(multiprocessing.Process):
 
     async def get_proxy_ports(self) -> tuple[int, int]:
         """Returns tuple of form (xsub port, xpub port) for the ZMQ proxy."""
+        if not self._proxy_started:
+            raise RuntimeError("ZMQ proxy not started.")
         async with self._zmq_proxy_lock:
             if self._xsub_port is None or self._xpub_port is None:
                 ports_msg = await self._pull_socket.recv_multipart()

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -1,5 +1,7 @@
 """Provides Component class."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 import asyncio
 from collections import defaultdict
@@ -80,7 +82,7 @@ class Component(ABC, ExportMixin):
     @classmethod
     def _configure_io(cls) -> None:
         # Get all parent classes that are Component subclasses
-        parent_comps = [c for c in cls.__bases__ if issubclass(c, Component)]
+        parent_comps = cls._get_component_bases()
         # Create combined set of all io arguments from this class and all parents
         io_args: dict[str, set] = defaultdict(set)
         for c in parent_comps + [cls]:
@@ -109,6 +111,15 @@ class Component(ABC, ExportMixin):
             raise IOSetupError(
                 f"{cls.__name__} must extend Component abstract base class io arguments"
             )
+
+    @classmethod
+    def _get_component_bases(cls) -> list[_t.Type[Component]]:
+        bases = []
+        for base in cls.__bases__:
+            if issubclass(base, Component):
+                bases.append(base)
+                bases.extend(base._get_component_bases())
+        return bases
 
     # Prevents type-checker errors on public component IO attributes
     def __getattr__(self, key: str) -> _t.Any:

--- a/plugboard/connector/zmq_channel.py
+++ b/plugboard/connector/zmq_channel.py
@@ -338,7 +338,7 @@ class ZMQConnector(_ZMQConnector):
         super().__init__(*args, **kwargs)
         match self.spec.mode:
             case ConnectorMode.PIPELINE:
-                zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnector
+                zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnectorV2
             case ConnectorMode.PUBSUB:
                 print(f"{settings=}")
                 if settings.flags.zmq_pubsub_proxy:

--- a/plugboard/connector/zmq_channel.py
+++ b/plugboard/connector/zmq_channel.py
@@ -26,7 +26,7 @@ ZMQ_CONFIRM_MSG: str = "__PLUGBOARD_CHAN_CONFIRM_MSG__"
 
 # Collection of poll tasks for ZMQ channels required to create strong refs to polling tasks
 # to avoid destroying tasks before they are done on garbage collection. Is there a better way?
-_zmq_poller_tasks: set[asyncio.Task] = set()
+_zmq_proxy_tasks: set[asyncio.Task] = set()
 _zmq_exchange_addr_tasks: set[asyncio.Task] = set()
 
 
@@ -190,6 +190,71 @@ class _ZMQPipelineConnector(_ZMQConnector):
         return self._recv_channel
 
 
+class _ZMQPipelineConnectorV2(_ZMQConnector):
+    """`_ZMQPipelineConnectorV2` connects components in pipeline mode using `ZMQChannel`."""
+
+    def __init__(self, *args: _t.Any, **kwargs: _t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._topic = str(self.spec.id)
+        self._xsub_port: _t.Optional[int] = None
+        self._xpub_port: _t.Optional[int] = None
+
+        self._push_socket: zmq.asyncio.Socket = create_socket(
+            zmq.PUSH, [(zmq.SNDHWM, self._maxsize)]
+        )
+        self._push_port: int = self._push_socket.bind_to_random_port("tcp://*")
+
+        self._proxy_task: asyncio.Task = asyncio.create_task(self._start_proxy())
+        _zmq_proxy_tasks.add(self._proxy_task)
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        for attr in ("_push_socket", "_proxy_task"):
+            if attr in state:
+                del state[attr]
+        return state
+
+    async def _start_proxy(self) -> None:
+        _, xpub_port = await self._get_proxy_ports()
+
+        sub_socket = create_socket(
+            zmq.SUB, [(zmq.RCVHWM, self._maxsize), (zmq.SUBSCRIBE, self._topic.encode("utf8"))]
+        )
+        sub_socket.connect(f"{self._zmq_address}:{xpub_port}")
+        try:
+            while True:
+                msg = await sub_socket.recv_multipart()
+                await self._push_socket.send_multipart(msg)
+        finally:
+            sub_socket.close(linger=0)
+            self._push_socket.close(linger=0)
+
+    @inject
+    async def _get_proxy_ports(
+        self, zmq_proxy: ZMQProxy = Provide[DI.zmq_proxy]
+    ) -> tuple[int, int]:
+        if self._xsub_port is not None and self._xpub_port is not None:
+            return self._xsub_port, self._xpub_port
+        await zmq_proxy.start_proxy(zmq_address=self._zmq_address, maxsize=self._maxsize)
+        self._xsub_port, self._xpub_port = await zmq_proxy.get_proxy_ports()
+        return self._xsub_port, self._xpub_port
+
+    async def connect_send(self) -> ZMQChannel:
+        """Returns a `ZMQChannel` for sending messages."""
+        await self._get_proxy_ports()
+        send_socket = create_socket(zmq.PUB, [(zmq.SNDHWM, self._maxsize)])
+        send_socket.connect(f"{self._zmq_address}:{self._xsub_port}")
+        await asyncio.sleep(0.1)  # Ensure connections established before first send. Better way?
+        return ZMQChannel(send_socket=send_socket, topic=self._topic, maxsize=self._maxsize)
+
+    async def connect_recv(self) -> ZMQChannel:
+        """Returns a `ZMQChannel` for receiving messages."""
+        recv_socket = create_socket(zmq.PULL, [(zmq.RCVHWM, self._maxsize)])
+        recv_socket.connect(f"{self._zmq_address}:{self._push_port}")
+        await asyncio.sleep(0.1)  # Ensure connections established before first send. Better way?
+        return ZMQChannel(recv_socket=recv_socket, topic=self._topic, maxsize=self._maxsize)
+
+
 class _ZMQPubsubConnector(_ZMQConnector):
     """`_ZMQPubsubConnector` connects components in pubsub mode using `ZMQChannel`."""
 
@@ -204,7 +269,7 @@ class _ZMQPubsubConnector(_ZMQConnector):
         self._poller.register(self._xsub_socket, zmq.POLLIN)
         self._poller.register(self._xpub_socket, zmq.POLLIN)
         self._poll_task = asyncio.create_task(self._poll())
-        _zmq_poller_tasks.add(self._poll_task)
+        _zmq_proxy_tasks.add(self._poll_task)
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
@@ -296,7 +361,7 @@ class ZMQConnector(_ZMQConnector):
         super().__init__(*args, **kwargs)
         match self.spec.mode:
             case ConnectorMode.PIPELINE:
-                zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnector
+                zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnectorV2
             case ConnectorMode.PUBSUB:
                 print(f"{settings=}")
                 if settings.flags.zmq_pubsub_proxy:

--- a/plugboard/connector/zmq_channel.py
+++ b/plugboard/connector/zmq_channel.py
@@ -284,7 +284,11 @@ class _ZMQPubsubConnectorProxy(_ZMQConnector):
 
 
 class _ZMQPipelineConnectorV2(_ZMQPubsubConnectorProxy):
-    """`_ZMQPipelineConnectorV2` connects components in pipeline mode using `ZMQChannel`."""
+    """`_ZMQPipelineConnectorV2` connects components in pipeline mode using `ZMQChannel`.
+
+    Relies on a ZMQ proxy to handle message routing between components. Messages from publishers are
+    proxied to the subscribers through a ZMQ Push socket in a coroutine running on the driver.
+    """
 
     def __init__(self, *args: _t.Any, **kwargs: _t.Any) -> None:
         super().__init__(*args, **kwargs)
@@ -329,7 +333,11 @@ class _ZMQPipelineConnectorV2(_ZMQPubsubConnectorProxy):
 
 
 class _ZMQPipelineConnectorV3(_ZMQPubsubConnectorProxy):
-    """`_ZMQPipelineConnectorV3` connects components in pipeline mode using `ZMQChannel`."""
+    """`_ZMQPipelineConnectorV3` connects components in pipeline mode using `ZMQChannel`.
+
+    Relies on a ZMQ proxy to handle message routing between components. Messages from publishers are
+    proxied to the subscribers through a ZMQ Push socket in a coroutine running on the proxy.
+    """
 
     def __init__(self, *args: _t.Any, **kwargs: _t.Any) -> None:
         super().__init__(*args, **kwargs)
@@ -380,7 +388,10 @@ class ZMQConnector(_ZMQConnector):
         super().__init__(*args, **kwargs)
         match self.spec.mode:
             case ConnectorMode.PIPELINE:
-                zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnectorV3
+                if settings.flags.zmq_pubsub_proxy:
+                    zmq_conn_cls: _t.Type[_ZMQConnector] = _ZMQPipelineConnectorV3
+                else:
+                    zmq_conn_cls = _ZMQPipelineConnector
             case ConnectorMode.PUBSUB:
                 print(f"{settings=}")
                 if settings.flags.zmq_pubsub_proxy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ docs = [
     "mkdocs-material~=9.5",
     "mkdocstrings[python]~=0.25",
 ]
+ray = [
+    "ray[default]>=2.42.1",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/test_component_event_handlers.py
+++ b/tests/integration/test_component_event_handlers.py
@@ -147,8 +147,9 @@ async def test_component_event_handlers(
     await a.io.close()
 
 
+@pytest.mark.anyio
 @pytest.fixture
-def field_connectors(connector_cls: _t.Type[Connector]) -> list[Connector]:
+async def field_connectors(connector_cls: _t.Type[Connector]) -> list[Connector]:
     """Fixture for a list of field connectors."""
     return [
         connector_cls(spec=ConnectorSpec(source="null.in_1", target="a.in_1")),

--- a/tests/integration/test_process_stop_event.py
+++ b/tests/integration/test_process_stop_event.py
@@ -14,7 +14,7 @@ from plugboard.connector import (
     ZMQConnector,
 )
 from plugboard.events import EventConnectorBuilder, StopEvent
-from plugboard.process import LocalProcess, Process
+from plugboard.process import LocalProcess, Process, RayProcess
 from plugboard.schemas import ConnectorSpec
 from tests.conftest import ComponentTestHelper
 
@@ -56,7 +56,7 @@ class B(ComponentTestHelper):
         (LocalProcess, AsyncioConnector),
         (LocalProcess, ZMQConnector),
         # (RayProcess, RayConnector),  # TODO : Pubsub/StopEvent unsupported. See https://github.com/plugboard-dev/plugboard/issues/101.
-        # (RayProcess, ZMQConnector),  # FIXME : Test assertion fails. See https://github.com/plugboard-dev/plugboard/issues/101.
+        (RayProcess, ZMQConnector),
     ],
 )
 async def test_process_stop_event(
@@ -116,4 +116,4 @@ async def test_process_stop_event(
         # Because the B components receive the StopEvent on iter n+1, they will only receive n
         # outputs from A before shutting down the IOController, hence n.
         for c in [comp_b1, comp_b2, comp_b3, comp_b4, comp_b5]:
-            assert c.out_1 == iters_before_stop
+            assert c.in_1 == iters_before_stop

--- a/tests/integration/test_process_with_components_run.py
+++ b/tests/integration/test_process_with_components_run.py
@@ -10,7 +10,7 @@ import pytest
 
 from plugboard import exceptions
 from plugboard.component import IOController as IO
-from plugboard.connector import AsyncioConnector, Connector, RayConnector
+from plugboard.connector import AsyncioConnector, Connector, RayConnector, ZMQConnector
 from plugboard.process import LocalProcess, Process, RayProcess
 from plugboard.schemas import ConnectorSpec
 from tests.conftest import ComponentTestHelper
@@ -73,7 +73,9 @@ def tempfile_path() -> _t.Generator[Path, None, None]:
     "process_cls, connector_cls",
     [
         (LocalProcess, AsyncioConnector),
+        (LocalProcess, ZMQConnector),
         (RayProcess, RayConnector),
+        (RayProcess, ZMQConnector),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/integration/test_state_backend_multiprocess.py
+++ b/tests/integration/test_state_backend_multiprocess.py
@@ -57,8 +57,9 @@ class ConnectorTestHelper(ZMQConnector):
         return output
 
 
+@pytest.mark.asyncio
 @pytest.fixture
-def connectors() -> list[Connector]:
+async def connectors() -> list[Connector]:
     """Returns a list of connectors."""
     return [
         ConnectorTestHelper(spec=ConnectorSpec(source="A1.out_1", target="B1.in_1")),

--- a/tests/unit/test_channel.py
+++ b/tests/unit/test_channel.py
@@ -61,8 +61,9 @@ async def test_channel(connector_cls: type[Connector]) -> None:
     assert send_channel.is_closed
 
 
+@pytest.mark.anyio
 @pytest.mark.parametrize("connector_cls", [ZMQConnector])
-def test_multiprocessing_channel(connector_cls: type[Connector]) -> None:
+async def test_multiprocessing_channel(connector_cls: type[Connector]) -> None:
     """Tests the various Channel implementations in a multiprocess environment."""
     spec = ConnectorSpec(mode=ConnectorMode.PIPELINE, source="test.send", target="test.recv")
     connector = ConnectorBuilder(connector_cls=connector_cls).build(spec)

--- a/tests/unit/test_component_io_inheritance.py
+++ b/tests/unit/test_component_io_inheritance.py
@@ -33,6 +33,9 @@ def test_io_inheritance(io_args: dict[str, _t.Any], exc: _t.Optional[type[Except
         class _A(Component):
             io: IO = IO(**io_args)
 
+            async def step(self) -> None:
+                pass
+
         for k in io_args:
             assert set(getattr(_A.io, k)) > set(getattr(Component.io, k))
         for k in {"inputs", "outputs", "input_events", "output_events"} - set(io_args.keys()):
@@ -48,6 +51,9 @@ def test_io_inheritance(io_args: dict[str, _t.Any], exc: _t.Optional[type[Except
             input_events=[EventType1],
             output_events=[EventType2],
         )
+
+        async def step(self) -> None:
+            pass
 
     for k in {"inputs", "outputs", "input_events", "output_events"}:
         assert set(getattr(_B.io, k)) > set(getattr(_A.io, k))
@@ -76,6 +82,9 @@ def test_io_inheritance_abc(io_args: dict[str, _t.Any], exc: _t.Optional[type[Ex
             input_events=[EventType1],
             output_events=[EventType2],
         )
+
+        async def step(self) -> None:
+            pass
 
     for k in {"inputs", "outputs", "input_events", "output_events"}:
         assert set(getattr(_B.io, k)) > set(getattr(_A.io, k))

--- a/tests/unit/test_component_io_inheritance.py
+++ b/tests/unit/test_component_io_inheritance.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 import typing as _t
 
 import pytest
+from ray.util.multiprocessing import Pool
 
 from plugboard.component import IOController as IO
 from plugboard.component.component import Component
@@ -78,3 +79,61 @@ def test_io_inheritance_abc(io_args: dict[str, _t.Any], exc: _t.Optional[type[Ex
 
     for k in {"inputs", "outputs", "input_events", "output_events"}:
         assert set(getattr(_B.io, k)) > set(getattr(_A.io, k))
+
+
+@pytest.mark.parametrize("io_args, exc", [({"inputs": ["in_1", "in_2"]}, None)])
+def test_io_inheritance_ray(io_args: dict[str, _t.Any], exc: _t.Optional[type[Exception]]) -> None:
+    """Tests that `Component` subclasses inherit `IOController` attributes when running on Ray."""
+
+    def _test_io_inheritance_ray(
+        io_args: dict[str, _t.Any], exc: _t.Optional[type[Exception]]
+    ) -> None:
+        import typing as _t
+
+        from plugboard.component import IOController as IO
+
+        class EventType1(Event):
+            """An event type for testing."""
+
+            type: _t.ClassVar[str] = "event_1"
+
+        class EventType2(Event):
+            """An event type for testing."""
+
+            type: _t.ClassVar[str] = "event_2"
+
+        with pytest.raises(exc) if exc is not None else nullcontext():
+
+            class _A(Component):
+                io: IO = IO(**io_args)
+
+                async def step(self) -> None:
+                    pass
+
+            # On Ray, IO inheritance logic is applied at Component instantiation time until
+            # https://github.com/ray-project/ray/issues/42823 is resolved
+            a = _A(name="a")
+
+            for k in io_args:
+                assert set(getattr(a.io, k)) > set(getattr(Component.io, k))
+            for k in {"inputs", "outputs", "input_events", "output_events"} - set(io_args.keys()):
+                assert set(getattr(a.io, k)) == set(getattr(Component.io, k))
+
+        if exc is not None:
+            return
+
+        class _B(_A):
+            io: IO = IO(
+                inputs=["in_3"],
+                outputs=["out_1"],
+                input_events=[EventType1],
+                output_events=[EventType2],
+            )
+
+        b = _B(name="b")
+
+        for k in {"inputs", "outputs", "input_events", "output_events"}:
+            assert set(getattr(b.io, k)) > set(getattr(a.io, k))
+
+    with Pool(1) as pool:
+        pool.apply(_test_io_inheritance_ray, (io_args, exc))

--- a/uv.lock
+++ b/uv.lock
@@ -112,6 +112,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-cors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/9e/6cdce7c3f346d8fd487adf68761728ad8cd5fbc296a7b07b92518350d31f/aiohttp-cors-0.7.0.tar.gz", hash = "sha256:4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d", size = 35966 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/e7/e436a0c0eb5127d8b491a9b83ecd2391c6ff7dcd5548dfaec2080a2340fd/aiohttp_cors-0.7.0-py3-none-any.whl", hash = "sha256:0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e", size = 27564 },
+]
+
+[[package]]
 name = "aioitertools"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -566,6 +578,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "colorful"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/5f/38e40c3bc4107c39e4062d943026b8ee25154cb4b185b882f274a1ab65da/colorful-0.5.6.tar.gz", hash = "sha256:b56d5c01db1dac4898308ea889edcb113fbee3e6ec5df4bacffd61d5241b5b8d", size = 209280 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/61/39e7db0cb326c9c8f6a49fad4fc9c2f1241f05a4e10f0643fc31ce26a7e0/colorful-0.5.6-py2.py3-none-any.whl", hash = "sha256:eab8c1c809f5025ad2b5238a50bd691e26850da8cac8f90d660ede6ea1af9f1e", size = 201369 },
 ]
 
 [[package]]
@@ -1080,6 +1104,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/80/13b6456bfbf8bc854875e58d3a3bad297ee19ebdd693ce62a10fab007e7a/griffe-1.5.7.tar.gz", hash = "sha256:465238c86deaf1137761f700fb343edd8ffc846d72f6de43c3c345ccdfbebe92", size = 391503 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/67/b43330ed76f96be098c165338d47ccb952964ed77ba1d075247fbdf05c04/griffe-1.5.7-py3-none-any.whl", hash = "sha256:4af8ec834b64de954d447c7b6672426bb145e71605c74a4e22d510cc79fe7d8b", size = 128294 },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.71.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/95/aa11fc09a85d91fbc7dd405dcb2a1e0256989d67bf89fa65ae24b3ba105a/grpcio-1.71.0.tar.gz", hash = "sha256:2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c", size = 12549828 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/83/bd4b6a9ba07825bd19c711d8b25874cd5de72c2a3fbf635c3c344ae65bd2/grpcio-1.71.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:0ff35c8d807c1c7531d3002be03221ff9ae15712b53ab46e2a0b4bb271f38537", size = 5184101 },
+    { url = "https://files.pythonhosted.org/packages/31/ea/2e0d90c0853568bf714693447f5c73272ea95ee8dad107807fde740e595d/grpcio-1.71.0-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:b78a99cd1ece4be92ab7c07765a0b038194ded2e0a26fd654591ee136088d8d7", size = 11310927 },
+    { url = "https://files.pythonhosted.org/packages/ac/bc/07a3fd8af80467390af491d7dc66882db43884128cdb3cc8524915e0023c/grpcio-1.71.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:dc1a1231ed23caac1de9f943d031f1bc38d0f69d2a3b243ea0d664fc1fbd7fec", size = 5654280 },
+    { url = "https://files.pythonhosted.org/packages/16/af/21f22ea3eed3d0538b6ef7889fce1878a8ba4164497f9e07385733391e2b/grpcio-1.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6beeea5566092c5e3c4896c6d1d307fb46b1d4bdf3e70c8340b190a69198594", size = 6312051 },
+    { url = "https://files.pythonhosted.org/packages/49/9d/e12ddc726dc8bd1aa6cba67c85ce42a12ba5b9dd75d5042214a59ccf28ce/grpcio-1.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5170929109450a2c031cfe87d6716f2fae39695ad5335d9106ae88cc32dc84c", size = 5910666 },
+    { url = "https://files.pythonhosted.org/packages/d9/e9/38713d6d67aedef738b815763c25f092e0454dc58e77b1d2a51c9d5b3325/grpcio-1.71.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5b08d03ace7aca7b2fadd4baf291139b4a5f058805a8327bfe9aece7253b6d67", size = 6012019 },
+    { url = "https://files.pythonhosted.org/packages/80/da/4813cd7adbae6467724fa46c952d7aeac5e82e550b1c62ed2aeb78d444ae/grpcio-1.71.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:f903017db76bf9cc2b2d8bdd37bf04b505bbccad6be8a81e1542206875d0e9db", size = 6637043 },
+    { url = "https://files.pythonhosted.org/packages/52/ca/c0d767082e39dccb7985c73ab4cf1d23ce8613387149e9978c70c3bf3b07/grpcio-1.71.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:469f42a0b410883185eab4689060a20488a1a0a00f8bbb3cbc1061197b4c5a79", size = 6186143 },
+    { url = "https://files.pythonhosted.org/packages/00/61/7b2c8ec13303f8fe36832c13d91ad4d4ba57204b1c723ada709c346b2271/grpcio-1.71.0-cp312-cp312-win32.whl", hash = "sha256:ad9f30838550695b5eb302add33f21f7301b882937460dd24f24b3cc5a95067a", size = 3604083 },
+    { url = "https://files.pythonhosted.org/packages/fd/7c/1e429c5fb26122055d10ff9a1d754790fb067d83c633ff69eddcf8e3614b/grpcio-1.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:652350609332de6dac4ece254e5d7e1ff834e203d6afb769601f286886f6f3a8", size = 4272191 },
+    { url = "https://files.pythonhosted.org/packages/04/dd/b00cbb45400d06b26126dcfdbdb34bb6c4f28c3ebbd7aea8228679103ef6/grpcio-1.71.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:cebc1b34ba40a312ab480ccdb396ff3c529377a2fce72c45a741f7215bfe8379", size = 5184138 },
+    { url = "https://files.pythonhosted.org/packages/ed/0a/4651215983d590ef53aac40ba0e29dda941a02b097892c44fa3357e706e5/grpcio-1.71.0-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:85da336e3649a3d2171e82f696b5cad2c6231fdd5bad52616476235681bee5b3", size = 11310747 },
+    { url = "https://files.pythonhosted.org/packages/57/a3/149615b247f321e13f60aa512d3509d4215173bdb982c9098d78484de216/grpcio-1.71.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f9a412f55bb6e8f3bb000e020dbc1e709627dcb3a56f6431fa7076b4c1aab0db", size = 5653991 },
+    { url = "https://files.pythonhosted.org/packages/ca/56/29432a3e8d951b5e4e520a40cd93bebaa824a14033ea8e65b0ece1da6167/grpcio-1.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47be9584729534660416f6d2a3108aaeac1122f6b5bdbf9fd823e11fe6fbaa29", size = 6312781 },
+    { url = "https://files.pythonhosted.org/packages/a3/f8/286e81a62964ceb6ac10b10925261d4871a762d2a763fbf354115f9afc98/grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9c80ac6091c916db81131d50926a93ab162a7e97e4428ffc186b6e80d6dda4", size = 5910479 },
+    { url = "https://files.pythonhosted.org/packages/35/67/d1febb49ec0f599b9e6d4d0d44c2d4afdbed9c3e80deb7587ec788fcf252/grpcio-1.71.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:789d5e2a3a15419374b7b45cd680b1e83bbc1e52b9086e49308e2c0b5bbae6e3", size = 6013262 },
+    { url = "https://files.pythonhosted.org/packages/a1/04/f9ceda11755f0104a075ad7163fc0d96e2e3a9fe25ef38adfc74c5790daf/grpcio-1.71.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:1be857615e26a86d7363e8a163fade914595c81fec962b3d514a4b1e8760467b", size = 6643356 },
+    { url = "https://files.pythonhosted.org/packages/fb/ce/236dbc3dc77cf9a9242adcf1f62538734ad64727fabf39e1346ad4bd5c75/grpcio-1.71.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a76d39b5fafd79ed604c4be0a869ec3581a172a707e2a8d7a4858cb05a5a7637", size = 6186564 },
+    { url = "https://files.pythonhosted.org/packages/10/fd/b3348fce9dd4280e221f513dd54024e765b21c348bc475516672da4218e9/grpcio-1.71.0-cp313-cp313-win32.whl", hash = "sha256:74258dce215cb1995083daa17b379a1a5a87d275387b7ffe137f1d5131e2cfbb", size = 3601890 },
+    { url = "https://files.pythonhosted.org/packages/be/f8/db5d5f3fc7e296166286c2a397836b8b042f7ad1e11028d82b061701f0f7/grpcio-1.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:22c3bc8d488c039a199f7a003a38cb7635db6656fa96437a8accde8322ce2366", size = 4273308 },
 ]
 
 [[package]]
@@ -2582,6 +2634,29 @@ wheels = [
 ]
 
 [[package]]
+name = "opencensus"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "opencensus-context" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/ed/9fbdeb23a09e430d87b7d72d430484b88184633dc50f6bfb792354b6f661/opencensus-0.11.4-py2.py3-none-any.whl", hash = "sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864", size = 128225 },
+]
+
+[[package]]
+name = "opencensus-context"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/96/3b6f638f6275a8abbd45e582448723bffa29c1fb426721dedb5c72f7d056/opencensus-context-0.1.3.tar.gz", hash = "sha256:a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c", size = 4066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/68/162c97ea78c957d68ecf78a5c5041d2e25bd5562bdf5d89a6cbf7f8429bf/opencensus_context-0.1.3-py2.py3-none-any.whl", hash = "sha256:073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039", size = 5060 },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2797,6 +2872,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+ray = [
+    { name = "ray", extra = ["default"] },
+]
 test = [
     { name = "aiofile" },
     { name = "aiosqlite" },
@@ -2859,6 +2937,7 @@ docs = [
     { name = "mkdocs-material", specifier = "~=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = "~=0.25" },
 ]
+ray = [{ name = "ray", extras = ["default"], specifier = ">=2.42.1" }]
 test = [
     { name = "aiofile", specifier = "~=3.9" },
     { name = "aiosqlite", specifier = "~=0.20" },
@@ -3052,6 +3131,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/a1/0a2867e48b232b4f82c4929ef7135f2a5d72c3886b957dccf63c70aa2fcb/py_partiql_parser-0.6.1.tar.gz", hash = "sha256:8583ff2a0e15560ef3bc3df109a7714d17f87d81d33e8c38b7fed4e58a63215d", size = 17120 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/84/0e410c20bbe9a504fc56e97908f13261c2b313d16cbb3b738556166f044a/py_partiql_parser-0.6.1-py2.py3-none-any.whl", hash = "sha256:ff6a48067bff23c37e9044021bf1d949c83e195490c17e020715e927fe5b2456", size = 23520 },
+]
+
+[[package]]
+name = "py-spy"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/cd/9dacc04604dc4398ce5bed77ed59918ad0940f15165954d4aaa651cc640c/py_spy-0.4.0.tar.gz", hash = "sha256:806602ce7972782cc9c1e383f339bfc27bfb822d42485e6a3e0530ae5040e1f0", size = 253236 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/7e/02ca3ee68507db47afce769504060d71b4dc1455f0f9faa8d32fc7762221/py_spy-0.4.0-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f2cf3f7130e7d780471faa5957441d3b4e0ec39a79b2c00f4c33d494f7728428", size = 3617847 },
+    { url = "https://files.pythonhosted.org/packages/65/7c/d9e26cc4c8e91f96a3a65de04d2e2e4131fbcaf6830d10917d4fab9d6788/py_spy-0.4.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:47cdda4c34d9b6cb01f3aaeceb2e88faf57da880207fe72ff6ff97e9bb6cc8a9", size = 1761955 },
+    { url = "https://files.pythonhosted.org/packages/d2/e4/8fbfd219b7f282b80e6b2e74c9197850d2c51db8555705567bb65507b060/py_spy-0.4.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eee3d0bde85ca5cf4f01f012d461180ca76c24835a96f7b5c4ded64eb6a008ab", size = 2059471 },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/79a94a5ace810c13b730ce96765ca465c171b4952034f1be7402d8accbc1/py_spy-0.4.0-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c5f06ffce4c9c98b7fc9f5e67e5e7db591173f1351837633f3f23d9378b1d18a", size = 2067486 },
+    { url = "https://files.pythonhosted.org/packages/6d/90/fbbb038f826a83ed15ebc4ae606815d6cad6c5c6399c86c7ab96f6c60817/py_spy-0.4.0-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:87573e64dbfdfc89ba2e0f5e2f525aa84e0299c7eb6454b47ea335fde583a7a0", size = 2141433 },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/5e012669ebb687e546dc99fcfc4861ebfcf3a337b7a41af945df23140bb5/py_spy-0.4.0-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8bf2f3702cef367a489faa45177b41a6c31b2a3e5bd78c978d44e29340152f5a", size = 2732951 },
+    { url = "https://files.pythonhosted.org/packages/74/8b/dd8490660019a6b0be28d9ffd2bf1db967604b19f3f2719c0e283a16ac7f/py_spy-0.4.0-py2.py3-none-win_amd64.whl", hash = "sha256:77d8f637ade38367d944874776f45b703b7ac5938b1f7be8891f3a5876ddbb96", size = 1810770 },
 ]
 
 [[package]]
@@ -3483,6 +3577,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/6f/820b5e5e01851c9bdd00da31b02d20a2f477f37bbf02ee3e4423dc58707c/ray-2.42.1-cp312-cp312-win_amd64.whl", hash = "sha256:27d2fd8a945afb8c60685cab8107247a9fe43a4b2bed15f978e368341fcffb3b", size = 25221921 },
 ]
 
+[package.optional-dependencies]
+default = [
+    { name = "aiohttp" },
+    { name = "aiohttp-cors" },
+    { name = "colorful" },
+    { name = "grpcio" },
+    { name = "opencensus" },
+    { name = "prometheus-client" },
+    { name = "py-spy" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "smart-open" },
+    { name = "virtualenv" },
+]
+
 [[package]]
 name = "referencing"
 version = "0.36.2"
@@ -3779,6 +3888,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "smart-open"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/30/1f41c3d3b8cec82024b4b277bfd4e5b18b765ae7279eb9871fa25c503778/smart_open-7.1.0.tar.gz", hash = "sha256:a4f09f84f0f6d3637c6543aca7b5487438877a21360e7368ccf1f704789752ba", size = 72044 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/18/9a8d9f01957aa1f8bbc5676d54c2e33102d247e146c1a3679d3bd5cc2e3a/smart_open-7.1.0-py3-none-any.whl", hash = "sha256:4b8489bb6058196258bafe901730c7db0dcf4f083f316e97269c66f45502055b", size = 61746 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
This PR fixes most of the issues detailed in #101 by removing Ray dependence from the ZMQConnector and fixing a bug in the handling of IOController inheritance in Ray. Communication of zmq address information is now performed entirely using zmq sockets, removing the need for a Ray queue.

In addition, the issue mentioned in the fixme comment for the `_ZMQPipelineConnector` class wherin multiple calls to `connect_send` and `connect_recv` would result in distinct channels not connected with each other has been resolved by introducing alternative V2 and V3 implementations. These V2 and V3 implementations both correctly ensure that multiple calls to `connect_send` and `connect_recv` will result in channels that share the same data. The V2 and V3 implementations correctly implement the "pipeline" concept in that multiple producers will send data into the same data stream, and multiple consumers will compete for the same data messages which are fanned-in from the producers.

# Changes
- Replaces Ray queue based mechanism of sharing zmq address info with purely zmq based approach.
- Ensures that all component subclasses are considered when performing IOController inheritance by using a recursive function.
- Enhances the ZMQProxy class by adding a `add_push_socket` method which allows clients to request new fan-in push/pull type sockets to be proxied in the ZMQProxy subprocess.