### PR TITLE
refactor: Decouple step and event handling

### DIFF
--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -272,10 +272,11 @@ class Component(ABC, ExportMixin):
         self._logger.info("Component destroyed")
 
     def dict(self) -> dict[str, _t.Any]:  # noqa: D102
+        _io_data = getattr(self, "_io_data", {_io_key_in: {}, _io_key_out: {}})
         return {
             "id": self.id,
             "name": self.name,
-            **self._io_data,
+            **_io_data,
             "exports": {name: getattr(self, name, None) for name in self.exports or []},
         }
 

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -193,11 +193,15 @@ class Component(ABC, ExportMixin):
     def _can_step(self) -> bool:
         """Checks if the component can step.
 
-        - if a component requires inputs, it can only step if the inputs have been received;
-        - otherwise, a component which does not require inputs can always step.
+        - if a component has no input or output fields, it cannot step (purely event-driven case);
+        - if a component requires inputs, it can only step if all the inputs are available;
+        - otherwise, a component which has outputs but does not require inputs can always step.
         """
-        input_is_not_required = len(self.io.inputs) == 0
-        return input_is_not_required or self._field_inputs_ready
+        consumes_no_inputs = len(self.io.inputs) == 0
+        produces_no_outputs = len(self.io.outputs) == 0
+        if consumes_no_inputs and produces_no_outputs:
+            return False
+        return consumes_no_inputs or self._field_inputs_ready
 
     def _handle_step_wrapper(self) -> _t.Callable:
         self._step = self.step

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -209,8 +209,8 @@ class Component(ABC, ExportMixin):
         @wraps(self.step)
         async def _wrapper() -> None:
             await self.io.read()
-            self._bind_inputs()
             await self._handle_events()
+            self._bind_inputs()
             if self._can_step:
                 await self._step()
             self._bind_outputs()

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -202,6 +202,8 @@ class Component(ABC, ExportMixin):
     async def _handle_events(self) -> None:
         """Handles incoming events."""
         async with asyncio.TaskGroup() as tg:
+            # FIXME : If a StopEvent is received, processing of other events may hit
+            #       : IOStreamClosedError due to concurrent execution.
             while self.io.events[str(IODirection.INPUT)]:
                 event = self.io.events[str(IODirection.INPUT)].popleft()
                 tg.create_task(self._handle_event(event))

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -70,7 +70,7 @@ class Component(ABC, ExportMixin):
             output_events=self.__class__.io.output_events,
             namespace=self.name,
         )
-        self._io_data: dict[str, dict[str, _t.Any]] = {}
+        self._io_data: dict[str, dict[str, _t.Any]] = {_io_key_in: {}, _io_key_out: {}}
         self._io_inputs_received: bool = False
 
         self._logger = DI.logger.sync_resolve().bind(cls=self.__class__.__name__, name=self.name)
@@ -206,7 +206,9 @@ class Component(ABC, ExportMixin):
 
     def _bind_inputs(self) -> None:
         """Binds input fields to component fields."""
+        # Consume buffer data and reset to empty value
         field_inputs = self.io.buf_fields.pop(_io_key_in, {})
+        self.io.buf_fields[_io_key_in] = {}
         if field_inputs:
             self._io_inputs_received = True
         for field in self.io.inputs:

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -70,7 +70,7 @@ class Component(ABC, ExportMixin):
             output_events=self.__class__.io.output_events,
             namespace=self.name,
         )
-        self._io_data: dict[str, dict[str, _t.Any]] = {_io_key_in: {}, _io_key_out: {}}
+        self._io_data: dict[str, dict[str, _t.Any]] = {}
         self._io_inputs_received: bool = False
 
         self._logger = DI.logger.sync_resolve().bind(cls=self.__class__.__name__, name=self.name)
@@ -180,7 +180,11 @@ class Component(ABC, ExportMixin):
 
     @property
     def _can_step(self) -> bool:
-        """Checks if the component can step."""
+        """Checks if the component can step.
+
+        - if a component requires inputs, it can only step if the inputs have been received;
+        - otherwise, a component which does not require inputs can always step.
+        """
         input_is_not_required = len(self.io.inputs) == 0
         return input_is_not_required or self._io_inputs_received
 

--- a/plugboard/component/component.py
+++ b/plugboard/component/component.py
@@ -207,6 +207,7 @@ class Component(ABC, ExportMixin):
     def _bind_inputs(self) -> None:
         """Binds input fields to component fields."""
         # Consume buffer data and reset to empty value
+        # field_inputs = self.io.buf_fields.read()
         field_inputs = self.io.buf_fields.pop(_io_key_in, {})
         self.io.buf_fields[_io_key_in] = {}
         if field_inputs:
@@ -227,6 +228,7 @@ class Component(ABC, ExportMixin):
             field_default = getattr(self, field, None)
             self._io_data[_io_key_out][field] = field_default
         if self._can_step:
+            # self.io.buf_fields.write(self._io_data[_io_key_out])
             self.io.buf_fields[_io_key_out] = self._io_data[_io_key_out]
 
     async def _handle_events(self) -> None:
@@ -234,6 +236,10 @@ class Component(ABC, ExportMixin):
         async with asyncio.TaskGroup() as tg:
             # FIXME : If a StopEvent is received, processing of other events may hit
             #       : IOStreamClosedError due to concurrent execution.
+            # event_queue = self.io.buf_events.read()
+            # while event_queue:
+            #     event = event_queue.pop()
+            #     tg.create_task(self._handle_event(event))
             while self.io.buf_events[_io_key_in]:
                 event = self.io.buf_events[_io_key_in].popleft()
                 tg.create_task(self._handle_event(event))

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -113,9 +113,9 @@ class IOController:
                     if (e := task.exception()) is not None:
                         raise e
                     self._read_tasks.pop(task.get_name())
-                    self._set_read_tasks()
-                    await self._flush_internal_field_buffer()
-                    await self._flush_internal_event_buffer()
+                self._set_read_tasks()
+                await self._flush_internal_field_buffer()
+                await self._flush_internal_event_buffer()
             except* ChannelClosedError as eg:
                 await self.close()
                 raise self._build_io_stream_error(IODirection.INPUT, eg) from eg

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -209,7 +209,7 @@ class IOController:
             raise self._build_io_stream_error(IODirection.OUTPUT, eg) from eg
 
     async def _write_fields(self) -> None:
-        if _io_key_out not in self.buf_fields:
+        if not self.buf_fields[_io_key_out]:
             return
         async with asyncio.TaskGroup() as tg:
             for (field, _), chan in self._output_channels.items():

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -230,6 +230,7 @@ class IOController:
         async with asyncio.TaskGroup() as tg:
             for (field, _), chan in self._output_channels.items():
                 tg.create_task(self._write_field(field, chan))
+        self.buf_fields[_io_key_out] = {}  # Clear the output buffer after writing
 
     async def _write_field(self, field: str, channel: Channel) -> None:
         # item = self.buf_fields.outputs.pop(field)

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -142,6 +142,7 @@ class IOController:
         if self._has_received_events.is_set():
             async with self._has_received_events_lock:
                 self._has_received_events.clear()
+                # FIXME : Sort events by time stamp so events are processed in time order.
                 self.events[_io_key_in].extend(self._received_events)
                 self._received_events.clear()
 

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -170,7 +170,7 @@ class IOController:
         for key, chan in self._input_channels.items():
             field, _ = key
             task_name = f"field:{key}"
-            if key not in self._read_tasks:
+            if task_name not in self._read_tasks:
                 task = asyncio.create_task(self._read_field(key, chan))
                 task.set_name(task_name)
                 self._read_tasks[task_name] = task

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -165,23 +165,23 @@ class IOController:
         if self.buf_fields[_io_key_in]:
             return  # Don't read new data if buffered input data has not been consumed
         read_tasks = []
-        for (key, _), chan in self._input_channels.items():
+        for (field, _), chan in self._input_channels.items():
             # FIXME : Looks like multiple channels for same field will trample each other
-            if key not in self._read_tasks:
-                task = asyncio.create_task(self._read_channel("field", key, chan))
-                task.set_name(key)
-                self._read_tasks[key] = task
-            read_tasks.append(self._read_tasks[key])
+            if field not in self._read_tasks:
+                task = asyncio.create_task(self._read_channel("field", field, chan))
+                task.set_name(field)
+                self._read_tasks[field] = task
+            read_tasks.append(self._read_tasks[field])
         if len(read_tasks) == 0:
             return
         done, _ = await asyncio.wait(read_tasks, return_when=asyncio.ALL_COMPLETED)
         async with self._received_fields_lock:
             for task in done:
-                key = task.get_name()
-                self._read_tasks.pop(key)
+                field = task.get_name()
+                self._read_tasks.pop(field)
                 if (e := task.exception()) is not None:
                     raise e
-                self._received_fields[key] = task.result()
+                self._received_fields[field] = task.result()
 
     async def _read_events(self) -> None:
         fan_in = AsyncioChannel()

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -154,9 +154,9 @@ class IOController:
         if self._has_received_events.is_set():
             async with self._received_events_lock:
                 self._has_received_events.clear()
-                # FIXME : Sort events by time stamp so events are processed in time order.
                 # self.buf_events.inputs.push(self._received_events)
-                self.buf_events[_io_key_in].extend(self._received_events)
+                events = sorted(self._received_events, key=lambda e: e.timestamp)
+                self.buf_events[_io_key_in].extend(events)
                 self._received_events.clear()
 
     async def _read_fields(

--- a/plugboard/component/io_controller.py
+++ b/plugboard/component/io_controller.py
@@ -41,17 +41,20 @@ class IOController:
         self.output_events = output_events or []
         if set(self.initial_values.keys()) - set(self.inputs):
             raise ValueError("Initial values must be for input fields only.")
+
         self.buf_fields: dict[str, dict[str, _t.Any]] = {_io_key_in: {}, _io_key_out: {}}
         self.buf_events: dict[str, deque[Event]] = {_io_key_in: deque(), _io_key_out: deque()}
+
         self._input_channels: dict[tuple[str, str], Channel] = {}
         self._output_channels: dict[tuple[str, str], Channel] = {}
         self._input_event_channels: dict[str, Channel] = {}
         self._output_event_channels: dict[str, Channel] = {}
         self._input_event_types = {Event.safe_type(evt.type) for evt in self.input_events}
         self._output_event_types = {Event.safe_type(evt.type) for evt in self.output_events}
-        self._read_tasks: dict[str, asyncio.Task] = {}
         self._initial_values = {k: deque(v) for k, v in self.initial_values.items()}
+        self._read_tasks: dict[str, asyncio.Task] = {}
         self._is_closed = False
+
         self._logger = DI.logger.sync_resolve().bind(
             cls=self.__class__.__name__, namespace=self.namespace
         )

--- a/plugboard/library/data_writer.py
+++ b/plugboard/library/data_writer.py
@@ -7,7 +7,7 @@ from collections import defaultdict, deque
 import typing as _t
 
 from plugboard.component import Component
-from plugboard.component.io_controller import IOController, IODirection
+from plugboard.component.io_controller import IOController
 from plugboard.exceptions import IOSetupError
 from plugboard.schemas import ComponentArgsDict
 
@@ -76,7 +76,7 @@ class DataWriter(Component, ABC):
         """Binds input fields to component fields and append to internal buffer."""
         super()._bind_inputs()
         for field in self.io.inputs:
-            value = self._io_data[IODirection.INPUT][field]
+            value = getattr(self, field, None)
             self._buffer[field].append(value)
 
     async def _save_chunk(self) -> None:

--- a/plugboard/library/data_writer.py
+++ b/plugboard/library/data_writer.py
@@ -74,10 +74,10 @@ class DataWriter(Component, ABC):
 
     def _bind_inputs(self) -> None:
         """Binds input fields to component fields and append to internal buffer."""
+        super()._bind_inputs()
         for field in self.io.inputs:
-            data = self.io.data[IODirection.INPUT][field]
-            setattr(self, field, data)
-            self._buffer[field].append(data)
+            value = self._io_data[IODirection.INPUT][field]
+            self._buffer[field].append(value)
 
     async def _save_chunk(self) -> None:
         """Write data from the buffer."""

--- a/tests/integration/test_process_topology.py
+++ b/tests/integration/test_process_topology.py
@@ -118,7 +118,7 @@ async def test_multiple_inputs_to_one_field_process_topology() -> None:
     comp_c = C(name="comp_c")
     components = [comp_d1, comp_d2, comp_d3, comp_c]
 
-    # Connect both A.out_1 and B.out_1 to C.in_1
+    # Connect both D1.out_1 and D2.out_1 to C.in_1
     conn_d1c = AsyncioConnector(spec=ConnectorSpec(source="comp_d1.out_1", target="comp_c.in_1"))
     conn_d2c = AsyncioConnector(spec=ConnectorSpec(source="comp_d2.out_1", target="comp_c.in_1"))
     conn_d3c = AsyncioConnector(spec=ConnectorSpec(source="comp_d3.out_1", target="comp_c.in_2"))
@@ -130,7 +130,7 @@ async def test_multiple_inputs_to_one_field_process_topology() -> None:
     async with process:
         await process.run()
 
-    # We expect C.in_1 to have the last value received from either A or B
+    # We expect C.in_1 to have the last value received from either D1 or D2
     assert comp_c.in_1 in (3, 12)  # Either D1's final output (3) or D2's final output (3*4=12)
     assert comp_c.in_2 == 30  # Should be D3's final output (6*5=30)
 

--- a/tests/integration/test_process_topology.py
+++ b/tests/integration/test_process_topology.py
@@ -1,6 +1,9 @@
 """Integration tests for different `Process` topologies."""
 # ruff: noqa: D101,D102,D103
 
+import asyncio
+import typing as _t
+
 import pytest
 
 from plugboard.component import IOController as IO
@@ -18,6 +21,29 @@ class C(ComponentTestHelper):
     async def step(self) -> None:
         self.out_1, self.out_2 = self.in_1, self.in_2  # type: ignore
         await super().step()
+
+
+class D(ComponentTestHelper):
+    io = IO(outputs=["out_1"])
+
+    def __init__(self, iters: int, *args: _t.Any, factor: float = 1.0, **kwargs: _t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._iters = iters
+        self._factor = factor
+
+    async def init(self) -> None:
+        await super().init()
+        self._seq = iter(range(1, self._iters + 1))
+
+    async def step(self) -> None:
+        try:
+            value = next(self._seq)
+            self.out_1 = int(self._factor * value)
+            await asyncio.sleep(0.1)
+        except StopIteration:
+            await self.io.close()
+        else:
+            await super().step()
 
 
 @pytest.mark.anyio
@@ -76,6 +102,41 @@ async def test_branching_process_topology() -> None:
     # Check the final outputs
     assert comp_c.out_1 == 9
     assert comp_c.out_2 == 9 * 2
+
+    assert all(comp.is_finished for comp in components)
+
+    # Create a markdown diagram of the process without error
+    _ = markdown_diagram(process)
+
+
+@pytest.mark.anyio
+async def test_multiple_inputs_to_one_field_process_topology() -> None:
+    """Tests a `Process` topology with multiple inputs to a single field."""
+    comp_d1 = D(name="comp_d1", iters=3, factor=1)
+    comp_d2 = D(name="comp_d2", iters=3, factor=4)
+    comp_d3 = D(name="comp_d3", iters=6, factor=5)
+    comp_c = C(name="comp_c")
+    components = [comp_d1, comp_d2, comp_d3, comp_c]
+
+    # Connect both A.out_1 and B.out_1 to C.in_1
+    conn_d1c = AsyncioConnector(spec=ConnectorSpec(source="comp_d1.out_1", target="comp_c.in_1"))
+    conn_d2c = AsyncioConnector(spec=ConnectorSpec(source="comp_d2.out_1", target="comp_c.in_1"))
+    conn_d3c = AsyncioConnector(spec=ConnectorSpec(source="comp_d3.out_1", target="comp_c.in_2"))
+    connectors = [conn_d1c, conn_d2c, conn_d3c]
+
+    process = LocalProcess(components, connectors)
+
+    # Process should run without error
+    async with process:
+        await process.run()
+
+    # We expect C.in_1 to have the last value received from either A or B
+    assert comp_c.in_1 in (3, 12)  # Either D1's final output (3) or D2's final output (3*4=12)
+    assert comp_c.in_2 == 30  # Should be D3's final output (6*5=30)
+
+    # Both outputs should match the inputs
+    assert comp_c.out_1 == comp_c.in_1
+    assert comp_c.out_2 == comp_c.in_2
 
     assert all(comp.is_finished for comp in components)
 


### PR DESCRIPTION
# Summary
Closes #122 with a simple solution which checks for the presence of new input data in the `IOController` at each step and executes the inner `Component` `step` method only if new inputs have been received.

# Changes
- Changes the public interface of `IOController` replacing `data` and `events` with `buf_fields` and `buf_events` respectively.
- Changes the interaction of `Component` and `IOController` such that input data in the fields buffer, `buf_fields`, is consumed at each time step enabling detection of new input data and conditional execution of the inner `step` method.
- Introduces `IOBuffer` classes to handle input and output data buffers in the `IOController` class.
- Sorts received input events by timestamp in the `IOController`.
- Adds support for multiple input channels for a single input field where this would have previously caused overwriting of previously added input channels for the same field.