### PR TITLE
fix: Use process context manager when running in CLI

### DIFF
--- a/plugboard/cli/process/__init__.py
+++ b/plugboard/cli/process/__init__.py
@@ -39,8 +39,8 @@ def _build_process(config: ConfigSpec) -> Process:
 
 
 async def _run_process(process: Process) -> None:
-    await process.init()
-    await process.run()
+    async with process:
+        await process.run()
 
 
 @app.command()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,9 +22,11 @@ def test_cli_process_run() -> None:
         # Process must be built
         mock_process_builder.build.assert_called_once()
         # Process must be initialised
-        mock_process.init.assert_called_once()
+        mock_process.__aenter__.assert_called_once()
         # Process must be run
         mock_process.run.assert_called_once()
+        # Process must be destroyed
+        mock_process.__aexit__.assert_called_once()
 
 
 def test_cli_process_diagram() -> None:


### PR DESCRIPTION
# Summary
Closes #124, ensuring that the `destroy()` method gets called when running a process via the CLI.

# Changes
* Use context manager for running `Process` in CLI.