### PR TITLE
build: Update gchr.io cleanup action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -111,3 +111,4 @@ jobs:
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           delete-untagged: true
+          older-than: 30 days

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -108,8 +108,6 @@ jobs:
           push-to-registry: true
 
       - name: Delete untagged images
-        uses: actions/delete-package-versions@v5
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          package-name: 'plugboard'
-          package-type: 'container'
-          delete-only-untagged-versions: 'true'
+          delete-untagged: true


### PR DESCRIPTION
# Summary
Updates container registry cleanup action to use [dataaxiom/ghcr-cleanup-action](https://github.com/dataaxiom/ghcr-cleanup-action). This resolves a problem where required manifests are deleted when building multi-arch images, see https://github.com/actions/delete-package-versions/issues/90 and https://github.com/docker/build-push-action/issues/835.

# Changes
* Update registry cleanup action.