### PR TITLE
ci: Fix docker build CI on release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           git_hash_short=$(git rev-parse --short "$GITHUB_SHA")
           echo "GIT_HASH_SHORT=${git_hash_short}" >> $GITHUB_ENV
-          git_branch=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)" | grep -v HEAD)
+          git_branch=$(git branch -r --contains ${{ github.ref }} --merged ${{ github.ref }} --format "%(refname:lstrip=3)" | grep -v HEAD)
           echo "GIT_BRANCH=${git_branch}" >> $GITHUB_ENV
           git_branch_docker_safe=$(echo ${git_branch} | tr / -)
           echo "GIT_BRANCH_DOCKER_SAFE=${git_branch_docker_safe}" >> $GITHUB_ENV


### PR DESCRIPTION
# Summary
The Docker build CI stage failed on the last release - see [here](https://github.com/plugboard-dev/plugboard/actions/runs/14492867311/job/40653206131). This update fixes the CI.

# Changes
* Filter using the [`--merged`](https://git-scm.com/docs/git-branch) as well as `--contains`. Otherwise when run on `refs/heads/main` this command will return other branches, e.g. from open PRs, that also contain `main`.