### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
    directory: "/"
    schedule:
      interval: monthly
+   groups:
+    python-packages:
+      patterns:
+         - "*"
+      update-types:
+        - "minor"
+        - "patch"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you have found a possible vulnerability, please email `security at plugboard dot dev`.


### PR DESCRIPTION
# Summary
Updated configuration for dependabot.

# Changes
* Enables [grouped updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) so that we aren't flooded with PRs.
* Adds security policy markdown file.