### PR TITLE
chore: Update Codespaces to use copilot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,9 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-toolsai.jupyter",
-				"charliermarsh.ruff"
+				"charliermarsh.ruff",
+				"GitHub.copilot",
+				"GitHub.copilot-chat"
 			],
 			"settings": {
 				"[python]": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,7 @@ The package documentation uses [Material for MkDocs](https://squidfunk.github.io
 ```sh
 uv run mkdocs serve
 ```
+
+### Building example models
+
+This repo includes a custom LLM prompt for the [examples](examples/) folder. If you use GitHub Copilot, this can help you build a Plugboard model from a description of the process and/or the components that you would like to implement. We recommend switching to agent mode and allowing Copilot to implement the boilerplate code from your input prompt.


### PR DESCRIPTION
# Summary
Copilot is now enabled when working in Github codespaces.

# Changes
* Updated devcontainer configuration.
* Updated `CONTRIBUTING.md` to include guidance on Copilot usage.