### PR TITLE
docs: Add analytics to documentation site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.12'
+  GOOGLE_ANALYTICS_KEY: ${{ vars.GOOGLE_ANALYTICS_KEY }}
 
 jobs:
   publish:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -9,7 +9,7 @@ extra:
     provider: mike
   analytics:
     provider: google
-    property: G-99NL59QL5D
+    property: !ENV GOOGLE_ANALYTICS_KEY
   consent:
     title: Cookie consent
     description: >- 


### PR DESCRIPTION
# Summary
Enables analytics on the documentation site, so that we can understand which pages are most useful to users.

# Changes
* Enable Google Analytics.
* Add cookie notice.