### PR TITLE
ci: Update docker build workflow for uv workspaces

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "PACKAGE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Export requirements.txt file
-        run: uv export --all-extras --format requirements-txt --no-hashes --no-editable --no-dev --no-emit-project > requirements.txt
+        run: uv export --all-packages --all-extras --format requirements-txt --no-hashes --no-editable --no-default-groups --no-emit-workspace > requirements.txt
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
# Summary
The Docker build CI stage needs modification to allow it to provide the correct `requirements.txt` before building the Docker image.

# Changes
* Update the `uv export` command as required.