### PR TITLE
ci: Remove WIP setting on PR check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -18,5 +18,3 @@ jobs:
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          wip: true


### PR DESCRIPTION
# Summary
Removes the WIP feature in the PR check pipeline. No longer required now that this is a public repo, and otherwise requires write permissions.

# Changes
* Remove WIP setting.